### PR TITLE
[#16] 플레이어 레벨 갱신 API 구현

### DIFF
--- a/PaperMania/Server/Api/Dto/Request/UpdatePlayerLevelRequest.cs
+++ b/PaperMania/Server/Api/Dto/Request/UpdatePlayerLevelRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Server.Api.Dto.Request;
+
+public class UpdatePlayerLevelRequest
+{
+    public int Id { get; set; }
+    public int NewLevel { get; set; }
+    public int NewExp { get; set; }
+}

--- a/PaperMania/Server/Application/Port/IDataRepository.cs
+++ b/PaperMania/Server/Application/Port/IDataRepository.cs
@@ -6,5 +6,5 @@ public interface IDataRepository
 {
     Task<PlayerGameData?> ExistsPlayerNameAsync(string playerName);
     Task AddPlayerNameAsync(string playerName);
-    Task<PlayerGameData?> GetByPlayerByIdAsync(int userId);
+    Task<PlayerGameData?> GetPlayerDataByIdAsync(int userId);
 }

--- a/PaperMania/Server/Application/Port/IDataRepository.cs
+++ b/PaperMania/Server/Application/Port/IDataRepository.cs
@@ -7,4 +7,5 @@ public interface IDataRepository
     Task<PlayerGameData?> ExistsPlayerNameAsync(string playerName);
     Task AddPlayerNameAsync(string playerName);
     Task<PlayerGameData?> GetPlayerDataByIdAsync(int userId);
+    Task<PlayerGameData?> UpdatePlayerLevelAsync(int userId, int newLevel, int newExp);
 }

--- a/PaperMania/Server/Application/Port/IDataService.cs
+++ b/PaperMania/Server/Application/Port/IDataService.cs
@@ -9,4 +9,5 @@ public interface IDataService
     Task<PlayerGameData?> GetByPlayerByIdAsync(int userId);
     Task<int> GetPlayerLevelByUserIdAsync(int userId, string sessionId);
     Task<int> GetPlayerExpByUserIdAsync(int userId, string sessionId);
+    Task<PlayerGameData> UpdatePlayerLevelAsync(int userId, int level, int exp, string sessionId);
 }

--- a/PaperMania/Server/Infrastructure/Repository/DataRepository.cs
+++ b/PaperMania/Server/Infrastructure/Repository/DataRepository.cs
@@ -35,7 +35,7 @@ public class DataRepository : IDataRepository
         await _db.ExecuteAsync(sql, new { PlayerName = playerName });
     }
 
-    public async Task<PlayerGameData?> GetByPlayerByIdAsync(int userId)
+    public async Task<PlayerGameData?> GetPlayerDataByIdAsync(int userId)
     {
         var sql = @"
             SELECT id AS Id, player_name AS PlayerName, player_exp AS PlayerExp, player_level AS PlayerLevel

--- a/PaperMania/Server/Infrastructure/Repository/DataRepository.cs
+++ b/PaperMania/Server/Infrastructure/Repository/DataRepository.cs
@@ -45,4 +45,21 @@ public class DataRepository : IDataRepository
         
         return await _db.QueryFirstOrDefaultAsync<PlayerGameData>(sql, new { Id = userId });
     }
+
+    public async Task<PlayerGameData?> UpdatePlayerLevelAsync(int userId, int newLevel, int newExp)
+    {
+        var sql = @"
+            UPDATE player_game_data
+            SET player_level = @Level, player_exp = @Exp
+            WHERE id = @Id
+            RETURNING id, player_name AS PlayerName, player_exp AS PlayerExp, player_level AS PlayerLevel;
+            ";
+
+        return await _db.QueryFirstOrDefaultAsync<PlayerGameData>(sql, new
+        {
+            Level = newLevel,
+            Exp = newExp,
+            Id = userId
+        });
+    }
 }

--- a/PaperMania/Server/Infrastructure/Service/DataService.cs
+++ b/PaperMania/Server/Infrastructure/Service/DataService.cs
@@ -54,7 +54,7 @@ public class DataService : IDataService
 
     public async Task<PlayerGameData?> GetByPlayerByIdAsync(int userId)
     {
-        return await _dataRepository.GetByPlayerByIdAsync(userId);
+        return await _dataRepository.GetPlayerDataByIdAsync(userId);
     }
 
     public async Task<int> GetPlayerLevelByUserIdAsync(int userId, string sessionId)
@@ -82,7 +82,7 @@ public class DataService : IDataService
 
     private async Task<PlayerGameData> GetPlayerDataByUserId(int userId)
     {
-        var data = await _dataRepository.GetByPlayerByIdAsync(userId);
+        var data = await _dataRepository.GetPlayerDataByIdAsync(userId);
         if (data == null)
             throw new Exception($"Id: {userId}의 플레이어 데이터가 없습니다.");
 

--- a/PaperMania/Server/Infrastructure/Service/DataService.cs
+++ b/PaperMania/Server/Infrastructure/Service/DataService.cs
@@ -73,6 +73,16 @@ public class DataService : IDataService
         return data.PlayerExp;
     }
 
+    public async Task<PlayerGameData> UpdatePlayerLevelAsync(int userId, int level, int exp, string sessionId)
+    {
+        await ValidateSessionAsync(sessionId);
+        var data = await _dataRepository.UpdatePlayerLevelAsync(userId, level, exp);
+        if (data == null)
+            throw new Exception($"Id: {userId}의 플레이어 레벨 데이터가 없습니다.");
+
+        return data;
+    }
+
     private async Task ValidateSessionAsync(string sessionId)
     {
         var isValid = await _sessionService.ValidateSessionAsync(sessionId);


### PR DESCRIPTION
## 📚작업 내용

- 플레이어의 경험치 및 레벨을 갱신하는 API (``POST api/v1/data/level/{id}``) 구현
- ``UpdatePlayerLevelRequest`` Dto 통해 클라이언트로부터 갱신할 레벨/경험치 수신

## ◀️참고 사항

> 추가적으로 개발자들이 알았으면 하는 정보들을 작성해주세요.

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?

 
> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
