### PR TITLE
[#59] 세션 인가 방식에 UserId를 통한 인가 강화

### DIFF
--- a/PaperMania/Server/Application/Port/ISessionService.cs
+++ b/PaperMania/Server/Application/Port/ISessionService.cs
@@ -3,7 +3,7 @@
 public interface ISessionService
 {
     Task<string> CreateSessionAsync(int userId);
-    Task<bool> ValidateSessionAsync(string sessionId);
+    Task<bool> ValidateSessionAsync(string sessionId, int? userId = null);
     Task<int?> GetUserIdBySessionIdAsync(string sessionId);
     Task DeleteSessionAsync(string sessionId);
     Task RefreshSessionAsync(string sessionId);

--- a/PaperMania/Server/Infrastructure/Service/AccountService.cs
+++ b/PaperMania/Server/Infrastructure/Service/AccountService.cs
@@ -61,7 +61,11 @@ public class AccountService : IAccountService
 
     public async Task<bool> LogoutAsync(string sessionId)
     {
-        var isVaild = await _sessionService.ValidateSessionAsync(sessionId);
+        var userId = await _sessionService.GetUserIdBySessionIdAsync(sessionId);
+        if (userId == null)
+            return false;
+        
+        var isVaild = await _sessionService.ValidateSessionAsync(sessionId, userId.Value);
         if (!isVaild)
             return false;
         

--- a/PaperMania/Server/Infrastructure/Service/DataService.cs
+++ b/PaperMania/Server/Infrastructure/Service/DataService.cs
@@ -116,7 +116,11 @@ public class DataService : IDataService
 
     private async Task ValidateSessionAsync(string sessionId)
     {
-        var isValid = await _sessionService.ValidateSessionAsync(sessionId);
+        var userId = await _sessionService.GetUserIdBySessionIdAsync(sessionId);
+        if (userId == null)
+            throw new Exception($"세션 ID에 맞는 유저 ID가 없습니다. : Id : {userId}");
+        
+        var isValid = await _sessionService.ValidateSessionAsync(sessionId, userId.Value);
         if (!isValid)
             throw new UnauthorizedAccessException("세션이 유효하지 않습니다.");
     }


### PR DESCRIPTION
## 📚작업 내용

- 기존 sessionId만 받던 세션 검증 방식에 userId를 받아 redis에 저장된 Id와 비교

## ◀️참고 사항

- ``SessionSevice``의 ``ValidateSessionAsync`` 매서드 userId 파라미터 추가

## ✅체크리스트

> `[ ]`안에 x를 작성하면 체크박스를 체크할 수 있습니다.

- [x] 현재 의도하고자 하는 기능이 정상적으로 작동하나요?
- [x] 변경한 기능이 다른 기능을 깨뜨리지 않나요?

 
> *추후 필요한 체크리스트는 업데이트 될 예정입니다.*
